### PR TITLE
Making compatible for new concourse

### DIFF
--- a/ci/c0-gcp-concourse-ert-poc.yml
+++ b/ci/c0-gcp-concourse-ert-poc.yml
@@ -107,7 +107,10 @@ jobs:
   - task: wipe-env
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
       outputs:
@@ -138,7 +141,10 @@ jobs:
   - task: init-public-ips
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
       run:
@@ -174,7 +180,10 @@ jobs:
   - task: upload-opsman
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: pivnet-opsmgr
@@ -189,7 +198,10 @@ jobs:
   - task: deploy-iaas
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: opsman-metadata
@@ -240,7 +252,11 @@ jobs:
   - task: config-opsman
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
+
       inputs:
         - name: gcp-concourse
         - name: tool-om
@@ -280,7 +296,10 @@ jobs:
   - task: deploy-director
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: tool-om
@@ -340,7 +359,10 @@ jobs:
   - task: upload-ert
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: tool-om
@@ -381,7 +403,10 @@ jobs:
   - task: deploy-ert
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: tool-om
@@ -433,7 +458,10 @@ jobs:
   - task: run-cats
     config:
       platform: linux
-      image: docker:///virtmerlin/c0-worker-gcp
+      image_resource:
+        type: docker-image
+        source:
+          repository: virtmerlin/c0-worker-gcp
       inputs:
         - name: gcp-concourse
         - name: tool-om


### PR DESCRIPTION
The syntax below, is no more compatible to concourse since 1.3.0
Not sure which version you are using
```yaml
image: docker:///virtmerlin/c0-worker-gcp
```

Good syntax is 
```yaml
image_resource:
   type: docker-image
   source:
     repository: virtmerlin/c0-worker-gcp
```


Second things I didn't change, but normally we put the task in outside yaml file, is more easy to debug, we can use `execute` it without running the full pipeline. It makes the pipeline more readable, and we can change the task without resubmitting the pipeline, but just by changing to the SCM(github).
