### PR TITLE
Fix wrong client name

### DIFF
--- a/ci/tasks/ert/upload-ert.sh
+++ b/ci/tasks/ert/upload-ert.sh
@@ -20,7 +20,7 @@ om-linux --target https://opsman.$pcf_ert_domain -k \
 
 opsman_host="opsman.$pcf_ert_domain"
 uaac target https://${opsman_host}/uaa --skip-ssl-validation > /dev/null 2>&1
-uaac token owner get opsman admin -s "" -p ${pcf_opsman_admin_passwd} > /dev/null 2>&1
+uaac token owner get opsman ${pcf_opsman_admin} -s "" -p ${pcf_opsman_admin_passwd} > /dev/null 2>&1
 export opsman_bearer_token=$(uaac context | grep access_token | awk -F ":" '{print$2}' | tr -d ' ')
 
 cf_product_version=$(curl -s -k -X GET -H "Content-Type: application/json" -H "Authorization: Bearer ${opsman_bearer_token}" "https://${opsman_host}/api/v0/available_products" | jq ' .[] | select ( .name == "cf") | .product_version ' | tr -d '"')


### PR DESCRIPTION
Hi,
It seems that the UAAC client admin is not the one created by the pipeline but the login is `${pcf_opsman_admin}`

Not sure if I am the only one to get this trouble, but at least this fix is working for me.