### PR TITLE
Add the option to use a shared DNS managed zone across multiple envs

### DIFF
--- a/ci/tasks/iaas/deploy-iaas.sh
+++ b/ci/tasks/iaas/deploy-iaas.sh
@@ -82,6 +82,7 @@ function fn_exec_tf {
       -var "gcp_terraform_subnet_ops_manager=${gcp_terraform_subnet_ops_manager}" \
       -var "gcp_terraform_subnet_ert=${gcp_terraform_subnet_ert}" \
       -var "gcp_terraform_subnet_services_1=${gcp_terraform_subnet_services_1}" \
+      -var "gcp_managed_zone=${gcp_managed_zone}" \
       -var "pcf_opsman_image_name=${pcf_opsman_image_name}" \
       -var "pcf_ert_domain=${pcf_ert_domain}" \
       -var "pcf_ert_ssl_cert=${pcf_ert_ssl_cert}" \

--- a/ci/tasks/init/wipe-env.sh
+++ b/ci/tasks/init/wipe-env.sh
@@ -152,6 +152,16 @@ echo "==========================================================================
 echo "All compute/networks objects with the prefix=$gcp_terraform_prefix in region=$gcp_region have been wiped !!!"
 echo "=============================================================================================="
 
+#If we were using a shared managed zone, wipe DNS record sets related to this prefix
+if [ -n "${gcp_managed_zone}" ]; then
+  echo "=============================================================================================="
+  echo "Removing DNS record sets for ${gcp_terraform_prefix} in managed zone ${gcp_managed_zone}"
+  echo "=============================================================================================="
+  gcloud dns record-sets export /tmp/old-record-sets -z "${gcp_managed_zone}" --zone-file-format
+  grep -v ".${gcp_terraform_prefix}." /tmp/old-record-sets > /tmp/new-record-sets
+  gcloud dns record-sets import /tmp/new-record-sets -z "${gcp_managed_zone}" --zone-file-format --delete-all-existing
+fi
+
 #Wipe Instance groups
 for y in ${ZONE[@]}; do
   echo "----------------------------------------------------------------------------------------------"


### PR DESCRIPTION
We use a single Google DNS managed zone for all of our PCF environments. This change will wipe the environment-specific records from a shared managed zone when `gcp_managed_zone` is set.

We also have corresponding terraform template changes to add the records to our existing managed zone instead of creating a new one, but I'm not sure how to make those changes conditional.
